### PR TITLE
use `alias_method_chain` rather than overriding `render` directly

### DIFF
--- a/lib/flash_render.rb
+++ b/lib/flash_render.rb
@@ -3,11 +3,9 @@ module FlashRender
   def self.included(base)
     # Protect from trying to augment modules that appear
     # as the result of adding other gems.
-    return if base != ActionController::Base
+    return unless base == ActionController::Base
 
-    base.class_eval do
-      alias_method_chain :render, :flash
-    end
+    base.alias_method_chain :render, :flash
   end
 
   def render_with_flash(*args)

--- a/lib/flash_render.rb
+++ b/lib/flash_render.rb
@@ -1,6 +1,16 @@
 module FlashRender
-  
-  def render(*args)
+
+  def self.included(base)
+    # Protect from trying to augment modules that appear
+    # as the result of adding other gems.
+    return if base != ActionController::Base
+
+    base.class_eval do
+      alias_method_chain :render, :flash
+    end
+  end
+
+  def render_with_flash(*args)
     options = args.extract_options!
   
     if alert = options.delete(:alert)
@@ -18,9 +28,8 @@ module FlashRender
     end
   
     args << options
-    super(*args)
+    render_without_flash(*args)
   end
-
 end
 
 if defined?(Rails::Railtie)


### PR DESCRIPTION
I noticed this wasn't playing nicely with [wicked_pdf](https://github.com/mileszs/wicked_pdf), which uses `alias_method_chain` to give different behaviour to the `render` method. FlashRender wasn't getting called as as result. Adding `alias_method_chain` to this gem fixes the issue (swapping the order of the gems in my Gemfile also worked, but this seems like a better way).
